### PR TITLE
[BE] issue-25 ResponseBody 수정 / ExceptionHandler 및 예외 관련 유틸 추가

### DIFF
--- a/src/main/java/com/todayworker/springboot/domain/board/es/document/BoardDocument.java
+++ b/src/main/java/com/todayworker/springboot/domain/board/es/document/BoardDocument.java
@@ -33,8 +33,8 @@ public class BoardDocument {
     @Field(type = FieldType.Text)
     private String regDate;
 
-    public static BoardDocument from(BoardVO vo) {
-        return new BoardDocument("board" + vo.getBno(),
+    public static BoardDocument from(BoardVO vo, String indexName) {
+        return new BoardDocument(indexName + vo.getBno(),
             vo.getBno(),
             vo.getCategoriName(),
             vo.getTitle(),

--- a/src/main/java/com/todayworker/springboot/domain/board/exception/BoardErrorCode.java
+++ b/src/main/java/com/todayworker/springboot/domain/board/exception/BoardErrorCode.java
@@ -1,0 +1,37 @@
+package com.todayworker.springboot.domain.board.exception;
+
+import com.todayworker.springboot.domain.common.exception.enums.BaseErrorCodeIF;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class BoardErrorCode implements BaseErrorCodeIF {
+
+    public static final String INVALID_WRITER = "올바르지 않은 작성자 ";
+    public static final String INVALID_BOARD = "유효하지 않은 게시글 ";
+    public static final String NON_EXIST_BOARD = "게시글이 존재하지 않습니다. ";
+    public static final String BOARD_TRANSACTION_PROCESSING_ERROR = "게시글 처리 중 에러가 발생하였습니다.";
+
+    private HttpStatus errorStatus;
+    private String errorMessage;
+
+    public static BoardErrorCode of(HttpStatus httpStatus, String errorMessage) {
+        return new BoardErrorCode(httpStatus, errorMessage);
+    }
+
+    public static BoardErrorCode of(HttpStatus httpStatus, String errorMessage, String param) {
+        return new BoardErrorCode(httpStatus, errorMessage, param);
+    }
+
+
+    private BoardErrorCode(HttpStatus httpStatus, String errorMessage) {
+        this.errorStatus = httpStatus;
+        this.errorMessage = errorMessage;
+    }
+
+    private BoardErrorCode(HttpStatus httpStatus, String errorMessage, String param) {
+        this.errorStatus = httpStatus;
+        this.errorMessage = errorMessage + "[" + param + "]";
+    }
+
+}

--- a/src/main/java/com/todayworker/springboot/domain/board/exception/BoardException.java
+++ b/src/main/java/com/todayworker/springboot/domain/board/exception/BoardException.java
@@ -1,0 +1,17 @@
+package com.todayworker.springboot.domain.board.exception;
+
+import com.todayworker.springboot.domain.common.exception.BaseException;
+import com.todayworker.springboot.domain.common.exception.enums.BaseErrorCodeIF;
+
+public class BoardException extends BaseException {
+
+    public BoardException(
+        BaseErrorCodeIF errorCode) {
+        super(errorCode);
+    }
+
+    public BoardException(
+        BaseErrorCodeIF errorCode, Throwable throwable) {
+        super(errorCode, throwable);
+    }
+}

--- a/src/main/java/com/todayworker/springboot/domain/board/jpa/entity/BoardEntity.java
+++ b/src/main/java/com/todayworker/springboot/domain/board/jpa/entity/BoardEntity.java
@@ -74,8 +74,8 @@ public class BoardEntity extends BaseTimeEntity {
         this.content = boardVO.getContent();
 
         // 댓글이 있다면 댓글도 엎여 쳐준다.
-        if (boardVO.getReply() != null) {
-            this.commentEntities = boardVO.getReply().stream()
+        if (boardVO.getCommentList() != null) {
+            this.commentEntities = boardVO.getCommentList().stream()
                 .map(it -> CommentEntity.fromReplyVO(it, this)).collect(
                     Collectors.toList());
         }
@@ -107,6 +107,7 @@ public class BoardEntity extends BaseTimeEntity {
             );
         }
 
+        // 댓글이 존재하는 경우 댓글 까지 List로 리턴.
         return new BoardVO(
             this.id,
             this.bno,

--- a/src/main/java/com/todayworker/springboot/domain/board/jpa/entity/CommentEntity.java
+++ b/src/main/java/com/todayworker/springboot/domain/board/jpa/entity/CommentEntity.java
@@ -1,6 +1,8 @@
 package com.todayworker.springboot.domain.board.jpa.entity;
 
 import com.todayworker.springboot.domain.BaseTimeEntity;
+import com.todayworker.springboot.domain.board.exception.BoardErrorCode;
+import com.todayworker.springboot.domain.board.exception.BoardException;
 import com.todayworker.springboot.domain.board.vo.ReplyVO;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -13,6 +15,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
 
 @Entity
 @Table(name = "comments")
@@ -53,7 +56,9 @@ public class CommentEntity extends BaseTimeEntity {
 
     public void modifyComment(ReplyVO replyVO) {
         if (!replyVO.getUser().equals(this.user)) {
-            throw new RuntimeException("글 작성자만 수정이 가능합니다.");
+            throw new BoardException(
+                BoardErrorCode.of(HttpStatus.FORBIDDEN, BoardErrorCode.INVALID_WRITER,
+                    "글 작성자만 수정 가능합니다."));
         }
 
         this.content = replyVO.getContent();

--- a/src/main/java/com/todayworker/springboot/domain/board/vo/BoardDetailVO.java
+++ b/src/main/java/com/todayworker/springboot/domain/board/vo/BoardDetailVO.java
@@ -1,8 +1,0 @@
-package com.todayworker.springboot.domain.board.vo;
-
-import lombok.Data;
-
-@Data
-public class BoardDetailVO {
-    // TODO : not yet implement
-}

--- a/src/main/java/com/todayworker/springboot/domain/board/vo/BoardVO.java
+++ b/src/main/java/com/todayworker/springboot/domain/board/vo/BoardVO.java
@@ -21,16 +21,18 @@ public class BoardVO {
     // TODO : 투표 / 해시태그 설명이 필요할 듯 합니다.
     // 투표 항목
     List<String> voteList;
+
     // 해시태그 목록
     List<String> tagList;
-    List<ReplyVO> reply;
+
+    List<ReplyVO> commentList;
 
     public List<ReplyVO> saveNewComment(ReplyVO replyVO) {
-        if (reply == null || reply.isEmpty()) {
-            this.reply = new ArrayList<>();
+        if (commentList == null) {
+            this.commentList = new ArrayList<>();
         }
 
-        this.reply.add(replyVO);
-        return this.reply;
+        this.commentList.add(replyVO);
+        return this.commentList;
     }
 }

--- a/src/main/java/com/todayworker/springboot/domain/board/vo/ReplyVO.java
+++ b/src/main/java/com/todayworker/springboot/domain/board/vo/ReplyVO.java
@@ -13,6 +13,6 @@ public class ReplyVO {
     private String content;
     private String user;
     private String regDate;
-    private Boolean isRecomment;
+    private Boolean isRecomment; // TODO : 이건 무슨 필드 일까요?
 
 }

--- a/src/main/java/com/todayworker/springboot/domain/common/dto/BaseErrorResponse.java
+++ b/src/main/java/com/todayworker/springboot/domain/common/dto/BaseErrorResponse.java
@@ -1,0 +1,20 @@
+package com.todayworker.springboot.domain.common.dto;
+
+import com.todayworker.springboot.domain.common.exception.BaseException;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BaseErrorResponse {
+
+    int errorCode;
+    String errorMessage;
+
+    public static BaseErrorResponse createErrorResponse(BaseException baseException) {
+        return new BaseErrorResponse(baseException.getErrorCode(), baseException.getErrorMessage());
+    }
+}

--- a/src/main/java/com/todayworker/springboot/domain/common/dto/PageableRequest.java
+++ b/src/main/java/com/todayworker/springboot/domain/common/dto/PageableRequest.java
@@ -1,4 +1,4 @@
-package com.todayworker.springboot.domain.common;
+package com.todayworker.springboot.domain.common.dto;
 
 import java.util.Date;
 import lombok.Data;

--- a/src/main/java/com/todayworker/springboot/domain/common/exception/BaseException.java
+++ b/src/main/java/com/todayworker/springboot/domain/common/exception/BaseException.java
@@ -1,0 +1,64 @@
+package com.todayworker.springboot.domain.common.exception;
+
+import com.todayworker.springboot.domain.common.exception.enums.BaseErrorCodeIF;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class BaseException extends RuntimeException {
+
+    HttpStatus errorStatus;
+    int errorCode;
+    String errorMessage;
+    String description;
+    Throwable cause;
+
+    public BaseException(HttpStatus httpStatus, String message, Throwable throwable) {
+        super(message, throwable);
+        this.errorStatus = httpStatus;
+        this.errorCode = httpStatus.value();
+        this.errorMessage = message;
+    }
+
+    public BaseException(BaseErrorCodeIF errorCode) {
+        super("[ErrorCode] : " + errorCode.getErrorStatus() + "\n"
+            + "[ErrorMessage] : " + errorCode.getErrorMessage() + "\n");
+        this.errorCode = errorCode.getErrorStatus().value();
+        this.errorMessage = errorCode.getErrorMessage();
+        this.errorStatus = errorCode.getErrorStatus();
+    }
+
+
+    public BaseException(BaseErrorCodeIF errorCode, String description) {
+        super("[ErrorCode] : " + errorCode.getErrorStatus() + "\n"
+            + "[ErrorMessage] : " + errorCode.getErrorMessage() + "\n"
+            + "[Description] : " + description + "\n");
+        this.errorCode = errorCode.getErrorStatus().value();
+        this.description = description;
+        this.errorMessage = errorCode.getErrorMessage();
+        this.errorStatus = errorCode.getErrorStatus();
+    }
+
+    public BaseException(BaseErrorCodeIF errorCode, Throwable throwable) {
+        super("[ErrorCode] : " + errorCode.getErrorStatus() + "\n"
+                + "[ErrorMessage] : " + errorCode.getErrorMessage() + "\n"
+            , throwable);
+        this.errorCode = errorCode.getErrorStatus().value();
+        this.errorMessage = errorCode.getErrorMessage();
+        this.errorStatus = errorCode.getErrorStatus();
+        this.cause = throwable;
+    }
+
+    public BaseException(BaseErrorCodeIF errorCode, String description, Throwable throwable) {
+        super("[ErrorCode] : " + errorCode.getErrorStatus() + "\n"
+                + "[ErrorMessage] : " + errorCode.getErrorMessage() + "\n"
+                + "[Description] : " + description + "\n"
+            , throwable);
+        this.errorCode = errorCode.getErrorStatus().value();
+        this.description = description;
+        this.errorMessage = errorCode.getErrorMessage();
+        this.errorStatus = errorCode.getErrorStatus();
+        this.cause = throwable;
+    }
+
+}

--- a/src/main/java/com/todayworker/springboot/domain/common/exception/enums/BaseErrorCode.java
+++ b/src/main/java/com/todayworker/springboot/domain/common/exception/enums/BaseErrorCode.java
@@ -1,0 +1,18 @@
+package com.todayworker.springboot.domain.common.exception.enums;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum BaseErrorCode implements BaseErrorCodeIF {
+
+    UNKNOWN_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알수 없는 서버 에러 입니다.");
+
+    private HttpStatus errorStatus;
+    private String errorMessage;
+
+    BaseErrorCode(HttpStatus httpStatus, String errorMessage) {
+        this.errorStatus = httpStatus;
+        this.errorMessage = errorMessage;
+    }
+}

--- a/src/main/java/com/todayworker/springboot/domain/common/exception/enums/BaseErrorCodeIF.java
+++ b/src/main/java/com/todayworker/springboot/domain/common/exception/enums/BaseErrorCodeIF.java
@@ -1,0 +1,10 @@
+package com.todayworker.springboot.domain.common.exception.enums;
+
+import org.springframework.http.HttpStatus;
+
+public interface BaseErrorCodeIF {
+
+    HttpStatus getErrorStatus();
+
+    String getErrorMessage();
+}

--- a/src/main/java/com/todayworker/springboot/domain/common/exception/handler/BaseExceptionHandler.java
+++ b/src/main/java/com/todayworker/springboot/domain/common/exception/handler/BaseExceptionHandler.java
@@ -1,0 +1,32 @@
+package com.todayworker.springboot.domain.common.exception.handler;
+
+import com.todayworker.springboot.domain.common.dto.BaseErrorResponse;
+import com.todayworker.springboot.domain.common.exception.BaseException;
+import com.todayworker.springboot.domain.common.exception.enums.BaseErrorCode;
+import javax.servlet.http.HttpServletRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@ControllerAdvice
+public class BaseExceptionHandler {
+
+    @ExceptionHandler({BaseException.class})
+    @ResponseBody
+    public ResponseEntity<BaseErrorResponse> handleCommonException(
+        BaseException e, HttpServletRequest request) {
+        return new ResponseEntity(BaseErrorResponse.createErrorResponse(e), e.getErrorStatus());
+    }
+
+    @ExceptionHandler({Exception.class})
+    public ResponseEntity<BaseErrorResponse> handleException(
+        Exception e, HttpServletRequest request) {
+        request.getSession();
+
+        BaseException boxedException = new BaseException(BaseErrorCode.UNKNOWN_SERVER_ERROR, e);
+        return new ResponseEntity(
+            BaseErrorResponse.createErrorResponse(boxedException),
+            boxedException.getErrorStatus());
+    }
+}

--- a/src/main/java/com/todayworker/springboot/web/controller/BoardController.java
+++ b/src/main/java/com/todayworker/springboot/web/controller/BoardController.java
@@ -2,109 +2,75 @@ package com.todayworker.springboot.web.controller;
 
 import com.todayworker.springboot.domain.board.vo.BoardVO;
 import com.todayworker.springboot.domain.board.vo.ReplyVO;
-import com.todayworker.springboot.domain.common.PageableRequest;
-import com.todayworker.springboot.domain.config.ResultVO;
+import com.todayworker.springboot.domain.common.dto.PageableRequest;
 import com.todayworker.springboot.web.service.BoardServiceIF;
-import com.todayworker.springboot.web.service.ReplyServiceIF;
+import com.todayworker.springboot.web.service.CommentServiceIF;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
 
 @RequiredArgsConstructor // 생성자 주입 어노테이션 => final 필드 변수
 @RestController
-@RequestMapping("board/")
+@RequestMapping("board")
 public class BoardController {
 
     private static final Logger LOG = LoggerFactory.getLogger(BoardController.class);
 
-    private final BoardServiceIF service;
+    private final BoardServiceIF boardService;
 
-    private final ReplyServiceIF replyService;
+    private final CommentServiceIF commentService;
 
-    @ResponseBody
-    @RequestMapping(value = "get-board-list.do", method = RequestMethod.POST)
-    public ResultVO getBoardList(@RequestBody PageableRequest request) throws Exception {
+    @PostMapping(value = "/get-board-list.do")
+    public List<BoardVO> getBoardList(@RequestBody PageableRequest request) {
         LOG.info("GetBoardList");
-        ResultVO result = new ResultVO(false, null);
-        result.setData(service.getBoardList(request));
-        return result;
+        return boardService.getBoardList(request);
     }
 
-    @ResponseBody
-    @RequestMapping(value = "get-board-detail.do", method = RequestMethod.POST)
-    public ResultVO getBoardDetail(@RequestBody BoardVO vo) throws Exception {
+    @PostMapping(value = "/get-board-detail.do")
+    public BoardVO getBoardDetail(@RequestBody BoardVO vo) {
         LOG.info("GetBoardDetail");
-        ResultVO result = new ResultVO(false, null);
-        result.setData(service.getBoardDetail(vo));
-        result.setSuccess(true);
-        return result;
+        return boardService.getBoard(vo);
     }
 
-    @ResponseBody
-    @RequestMapping(value = "insert-board.do", method = RequestMethod.POST)
-    public ResultVO insertBoard(@RequestBody BoardVO vo) throws Exception {
+    @PostMapping(value = "insert-board.do")
+    public BoardVO insertBoard(@RequestBody BoardVO vo) {
         LOG.info("InsertBoard");
-        ResultVO result = new ResultVO(false, null);
-        result.setData(service.insertBoard(vo));
-        result.setSuccess(true);
-        return result;
-
+        return boardService.insertBoard(vo);
     }
 
-    @ResponseBody
-    @RequestMapping(value = "update-board.do", method = RequestMethod.POST)
-    public ResultVO updateBoard(@RequestBody BoardVO vo) throws Exception {
+    @PostMapping(value = "update-board.do")
+    public BoardVO updateBoard(@RequestBody BoardVO vo) {
         LOG.info("UpdateBoard");
-        ResultVO result = new ResultVO(false, null);
-        result.setData(service.updateBoard(vo));
-        result.setSuccess(true);
-        return result;
-
+        return boardService.updateBoard(vo);
     }
 
-    @ResponseBody
-    @RequestMapping(value = "delete-board.do", method = RequestMethod.POST)
-    public ResultVO deleteBoard(@RequestBody BoardVO vo) throws Exception {
+    @PostMapping(value = "delete-board.do")
+    public boolean deleteBoard(@RequestBody BoardVO vo) {
         LOG.info("DeleteBoard");
-        ResultVO result = new ResultVO(false, null);
-        result.setData(service.deleteBoard(vo));
-        result.setSuccess(true);
-        return result;
+        return boardService.deleteBoard(vo);
     }
 
-    @ResponseBody
-    @RequestMapping(value = "regist-reply.do", method = RequestMethod.POST)
-    public ResultVO registReply(@RequestBody ReplyVO vo) throws Exception {
+    @PostMapping(value = "regist-reply.do")
+    public boolean registReply(@RequestBody ReplyVO vo) throws Exception {
         LOG.info("registReply");
-        ResultVO result = new ResultVO(false, null);
-        result.setData(replyService.registerReply(vo));
-        result.setSuccess(true);
-        return result;
+        return commentService.registerReply(vo);
     }
 
-    @ResponseBody
-    @RequestMapping(value = "update-reply.do", method = RequestMethod.POST)
-    public ResultVO updateReply(@RequestBody ReplyVO vo) throws Exception {
+    @PostMapping(value = "update-reply.do")
+    public boolean updateReply(@RequestBody ReplyVO vo) throws Exception {
         LOG.info("updateReply");
-        ResultVO result = new ResultVO(false, null);
-        result.setData(replyService.updateReply(vo));
-        result.setSuccess(true);
-        return result;
+        return commentService.updateReply(vo);
     }
 
-    @ResponseBody
-    @RequestMapping(value = "delete-reply.do", method = RequestMethod.POST)
-    public ResultVO deleteReply(@RequestBody ReplyVO vo) throws Exception {
+    @PostMapping(value = "delete-reply.do")
+    public boolean deleteReply(@RequestBody ReplyVO vo) throws Exception {
         LOG.info("deleteReply");
-        ResultVO result = new ResultVO(false, null);
-        result.setData(replyService.deleteReply(vo));
-        result.setSuccess(true);
-        return result;
+        return commentService.deleteReply(vo);
     }
 }

--- a/src/main/java/com/todayworker/springboot/web/service/BoardServiceIF.java
+++ b/src/main/java/com/todayworker/springboot/web/service/BoardServiceIF.java
@@ -1,19 +1,18 @@
 package com.todayworker.springboot.web.service;
 
-import com.todayworker.springboot.domain.board.vo.BoardDetailVO;
 import com.todayworker.springboot.domain.board.vo.BoardVO;
-import com.todayworker.springboot.domain.common.PageableRequest;
+import com.todayworker.springboot.domain.common.dto.PageableRequest;
 import java.util.List;
 
 public interface BoardServiceIF {
 
-    List<BoardVO> getBoardList(PageableRequest request) throws Exception;
+    List<BoardVO> getBoardList(PageableRequest request);
 
-    BoardDetailVO getBoardDetail(BoardVO vo) throws Exception;
+    BoardVO getBoard(BoardVO vo);
 
-    String insertBoard(BoardVO vo) throws Exception;
+    BoardVO insertBoard(BoardVO vo);
 
-    String updateBoard(BoardVO vo) throws Exception;
+    BoardVO updateBoard(BoardVO vo);
 
-    boolean deleteBoard(BoardVO vo) throws Exception;
+    boolean deleteBoard(BoardVO vo);
 }

--- a/src/main/java/com/todayworker/springboot/web/service/CommentService.java
+++ b/src/main/java/com/todayworker/springboot/web/service/CommentService.java
@@ -1,10 +1,13 @@
 package com.todayworker.springboot.web.service;
 
+import com.todayworker.springboot.domain.board.exception.BoardErrorCode;
+import com.todayworker.springboot.domain.board.exception.BoardException;
 import com.todayworker.springboot.domain.board.jpa.entity.CommentEntity;
 import com.todayworker.springboot.domain.board.jpa.repository.BoardJpaRepository;
 import com.todayworker.springboot.domain.board.jpa.repository.CommentJpaRepository;
 import com.todayworker.springboot.domain.board.vo.ReplyVO;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,9 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @Service
 @RequiredArgsConstructor
-public class ReplyService implements ReplyServiceIF {
-    // TODO : 댓글은 ES가 아닌 DB에서만 관리하도록 하겠습니다.
-    // TODO : 서비스 레이어에서는 로직이 실패하면 Exception을 Throw 하도록 하고, FE에 내려주는 에러 응답에 대해서는 ExceptionHandler를 통해서 처리하도록 하고자 합니다.
+public class CommentService implements CommentServiceIF {
 
     private final BoardJpaRepository boardJpaRepository;
     private final CommentJpaRepository commentJpaRepository;
@@ -23,7 +24,9 @@ public class ReplyService implements ReplyServiceIF {
     @Transactional(readOnly = true)
     public boolean registerReply(ReplyVO vo) {
         if (vo.getBno() == null) {
-            throw new IllegalArgumentException("유효하지 않은 댓글 등록 요청 [bno=null]");
+            throw new BoardException(
+                BoardErrorCode.of(HttpStatus.BAD_REQUEST, BoardErrorCode.INVALID_BOARD,
+                    "게시글 ID(bno)가 Null 일 수는 없습니다."));
         }
 
         boardJpaRepository.findBoardEntityByBno(vo.getBno()).ifPresent(it -> {
@@ -37,11 +40,15 @@ public class ReplyService implements ReplyServiceIF {
     @Override
     public boolean updateReply(ReplyVO vo) {
         if (vo.getBno() == null) {
-            throw new IllegalArgumentException("유효하지 않은 댓글 수정 요청 [bno=null]");
+            throw new BoardException(
+                BoardErrorCode.of(HttpStatus.BAD_REQUEST, BoardErrorCode.INVALID_BOARD,
+                    "게시글 ID(bno)가 Null 일 수는 없습니다."));
         }
 
         if (vo.getRno() == null) {
-            throw new IllegalArgumentException("유효하지 않은 댓글 수정 요청 [rno=null]");
+            throw new BoardException(
+                BoardErrorCode.of(HttpStatus.BAD_REQUEST, BoardErrorCode.INVALID_BOARD,
+                    "댓글 ID(rno)가 Null 일 수는 없습니다."));
         }
 
         CommentEntity updateComment = commentJpaRepository.findCommentEntityByRno(vo.getRno())

--- a/src/main/java/com/todayworker/springboot/web/service/CommentServiceIF.java
+++ b/src/main/java/com/todayworker/springboot/web/service/CommentServiceIF.java
@@ -3,7 +3,7 @@ package com.todayworker.springboot.web.service;
 
 import com.todayworker.springboot.domain.board.vo.ReplyVO;
 
-public interface ReplyServiceIF {
+public interface CommentServiceIF {
 
     boolean registerReply(ReplyVO vo);
 

--- a/src/test/java/com/todayworker/springboot/elasticsearch/helper/ElasticSearchExtension.java
+++ b/src/test/java/com/todayworker/springboot/elasticsearch/helper/ElasticSearchExtension.java
@@ -1,5 +1,8 @@
 package com.todayworker.springboot.elasticsearch.helper;
 
+import java.io.IOException;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import org.apache.http.HttpHost;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.client.RequestOptions;
@@ -15,10 +18,6 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.utility.DockerImageName;
 
-import java.io.IOException;
-import java.time.Duration;
-import java.time.temporal.ChronoUnit;
-
 // 참고 : https://honeyinfo7.tistory.com/301
 public class ElasticSearchExtension implements BeforeAllCallback, AfterAllCallback {
 
@@ -27,35 +26,41 @@ public class ElasticSearchExtension implements BeforeAllCallback, AfterAllCallba
 
     @Override
     public void beforeAll(ExtensionContext context) throws Exception {
-        elasticSearchContainer = new ElasticsearchContainer(DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch:7.9.2"))
-                .withExposedPorts(9200)
-                .withEnv("node.name","elasticSearch")
-                .withEnv("discovery.seed_hosts","elasticSearch")
+        elasticSearchContainer = new ElasticsearchContainer(
+            DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch:7.9.2"))
+            .withExposedPorts(9200)
+            .withEnv("node.name", "elasticSearch")
+            .withEnv("discovery.seed_hosts", "elasticSearch")
 //                .withEnv("cluster.initial_master_nodes","elasticSearch")
-                .withEnv("cluster.name","docker-cluster")
-                .withEnv("discovery.type","single-node")
-                .withEnv("ES_JAVA_OPTS", "-Xms128m -Xmx128m")
-                .withStartupTimeout(Duration.of(120, ChronoUnit.SECONDS));
+            .withEnv("cluster.name", "docker-cluster")
+            .withEnv("discovery.type", "single-node")
+            .withEnv("ES_JAVA_OPTS", "-Xms128m -Xmx128m")
+            .withStartupTimeout(Duration.of(120, ChronoUnit.SECONDS));
 
         elasticSearchContainer.start();
 
-        System.setProperty("spring.elasticsearch.rest.uris", String.format("http://localhost:%d",elasticSearchContainer.getFirstMappedPort()));
-        System.setProperty("elasticsearch.test.container.host.port", elasticSearchContainer.getFirstMappedPort().toString());
+        System.setProperty("spring.elasticsearch.rest.uris",
+            String.format("http://localhost:%d", elasticSearchContainer.getFirstMappedPort()));
+        System.setProperty("elasticsearch.test.container.host.port",
+            elasticSearchContainer.getFirstMappedPort().toString());
 
         // board 인덱스가 있는지 확인후 없으면 생성
-        for(String indexName : INDEX_NAMES) {
+        for (String indexName : INDEX_NAMES) {
             this.isExistIndex(indexName);
         }
     }
 
     @Override
     public void afterAll(ExtensionContext context) throws Exception {
-        elasticSearchContainer.stop();
+        // do nothing, Testcontainers handles container shutdown
+//        elasticSearchContainer.stop();
     }
 
     private void isExistIndex(String indexName) {
-        System.out.println("TEST ELASTIC SEARCH HOST : " + System.getProperty("spring.elasticsearch.rest.uris"));
-        RestHighLevelClient client = new RestHighLevelClient(RestClient.builder(HttpHost.create(System.getProperty("spring.elasticsearch.rest.uris"))));
+        System.out.println(
+            "TEST ELASTIC SEARCH HOST : " + System.getProperty("spring.elasticsearch.rest.uris"));
+        RestHighLevelClient client = new RestHighLevelClient(RestClient.builder(
+            HttpHost.create(System.getProperty("spring.elasticsearch.rest.uris"))));
         // 이 값에서 존재하는 인덱스를 삭제 할 것인지를 판단
         Boolean deleteFlag = false;
 
@@ -64,7 +69,8 @@ public class ElasticSearchExtension implements BeforeAllCallback, AfterAllCallba
 
             // 인덱스 생성 요청
             CreateIndexRequest createIndexRequest = new CreateIndexRequest(indexName);
-            createIndexRequest.settings(Settings.builder().put("index.number_of_shards", 1).put("index.number_of_replicas", 0));
+            createIndexRequest.settings(Settings.builder().put("index.number_of_shards", 1)
+                .put("index.number_of_replicas", 0));
             // 인덱스 삭제 요청
             DeleteIndexRequest deleteIndexRequest = new DeleteIndexRequest(indexName);
 
@@ -72,12 +78,13 @@ public class ElasticSearchExtension implements BeforeAllCallback, AfterAllCallba
                 boolean exists = client.indices().exists(request, RequestOptions.DEFAULT);
 
                 // 존재한다면 생성 X => 삭제를 원하면 deleteFlag로 삭제 가능
-                if(exists && deleteFlag) {
+                if (exists && deleteFlag) {
                     client.indices().delete(deleteIndexRequest, RequestOptions.DEFAULT);
                 }
                 // 존재하지 않는다면 생성
-                else if (!exists){
-                    CreateIndexResponse response = client.indices().create(createIndexRequest, RequestOptions.DEFAULT);
+                else if (!exists) {
+                    CreateIndexResponse response = client.indices()
+                        .create(createIndexRequest, RequestOptions.DEFAULT);
                 }
             } catch (IOException e) {
                 e.printStackTrace();

--- a/src/test/java/com/todayworker/springboot/elasticsearch/helper/MockElasticSearchExtension.java
+++ b/src/test/java/com/todayworker/springboot/elasticsearch/helper/MockElasticSearchExtension.java
@@ -1,0 +1,19 @@
+package com.todayworker.springboot.elasticsearch.helper;
+
+import com.todayworker.springboot.domain.board.es.repository.BoardElasticSearchRepository;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+public class MockElasticSearchExtension implements BeforeAllCallback {
+
+    @MockBean
+    BoardElasticSearchRepository boardElasticSearchRepository;
+
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+
+        System.setProperty("spring.elasticsearch.rest.uris", "http://localhost:9200");
+
+    }
+}

--- a/src/test/java/com/todayworker/springboot/web/controller/BoardControllerTest.java
+++ b/src/test/java/com/todayworker/springboot/web/controller/BoardControllerTest.java
@@ -1,5 +1,480 @@
 package com.todayworker.springboot.web.controller;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+import com.todayworker.springboot.domain.board.exception.BoardErrorCode;
+import com.todayworker.springboot.domain.board.exception.BoardException;
+import com.todayworker.springboot.domain.board.vo.BoardVO;
+import com.todayworker.springboot.domain.board.vo.ReplyVO;
+import com.todayworker.springboot.domain.common.dto.PageableRequest;
+import com.todayworker.springboot.elasticsearch.helper.ElasticSearchExtension;
+import com.todayworker.springboot.utils.DateUtils;
+import com.todayworker.springboot.utils.UuidUtils;
+import com.todayworker.springboot.web.service.BoardService;
+import com.todayworker.springboot.web.service.CommentService;
+import java.util.Arrays;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.web.servlet.HttpEncodingAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@ExtendWith({MockitoExtension.class, ElasticSearchExtension.class})
+@Import(HttpEncodingAutoConfiguration.class)
 public class BoardControllerTest {
 
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private BoardService boardService;
+
+    @MockBean
+    private CommentService commentService;
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    @DisplayName("게시글 정상 등록 RestAPI")
+    public void registerBoardSuccess() throws Exception {
+        when(boardService.insertBoard(any()))
+            .thenReturn(
+                new BoardVO(
+                    1L,
+                    UuidUtils.generateNoDashUUID(),
+                    "Category1",
+                    "title1",
+                    "content",
+                    0L,
+                    "user1",
+                    DateUtils.getDatetimeString(),
+                    null,
+                    null,
+                    null
+                )
+            );
+
+        BoardVO testBoard = new BoardVO(
+            null,
+            UuidUtils.generateNoDashUUID(),
+            "Category1",
+            "title1",
+            "content",
+            0L,
+            "user1",
+            DateUtils.getDatetimeString(),
+            null,
+            null,
+            null
+        );
+
+        mockMvc.perform(
+                post("/board/insert-board.do")
+                    .content(objectMapper.writeValueAsBytes(testBoard))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+            )
+            .andDo(print())
+            .andExpect(MockMvcResultMatchers.status().isOk());
+
+    }
+
+    @Test
+    @DisplayName("게시글 다건 조회(페이징)")
+    public void getBoardListPaging() throws Exception {
+
+        PageableRequest pageableRequest = new PageableRequest();
+        pageableRequest.setPageSize(10);
+        pageableRequest.setFromIndex(0);
+
+        when(boardService.getBoardList(any()))
+            .thenReturn(
+                Arrays.asList(
+                    new BoardVO(
+                        1L,
+                        UuidUtils.generateNoDashUUID(),
+                        "Category1",
+                        "title1",
+                        "content",
+                        0L,
+                        "user1",
+                        DateUtils.getDatetimeString(),
+                        null,
+                        null,
+                        null
+                    ),
+                    new BoardVO(
+                        2L,
+                        UuidUtils.generateNoDashUUID(),
+                        "Category2",
+                        "title2",
+                        "content",
+                        0L,
+                        "user2",
+                        DateUtils.getDatetimeString(),
+                        null,
+                        null,
+                        null
+                    ),
+                    new BoardVO(
+                        3L,
+                        UuidUtils.generateNoDashUUID(),
+                        "Category3",
+                        "title3",
+                        "content",
+                        0L,
+                        "user3",
+                        DateUtils.getDatetimeString(),
+                        null,
+                        null,
+                        null
+                    )
+                )
+            );
+
+        mockMvc.perform(
+                post("/board/get-board-list.do")
+                    .content(objectMapper.writeValueAsBytes(pageableRequest))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+            )
+            .andDo(print())
+            .andExpect(MockMvcResultMatchers.status().isOk());
+    }
+
+    @Test
+    @DisplayName("게시글 단건 조회 성공")
+    public void getBoardSuccess() throws Exception {
+
+        BoardVO testBoard = new BoardVO(
+            null,
+            UuidUtils.generateNoDashUUID(),
+            "Category1",
+            "title1",
+            "content",
+            0L,
+            "user1",
+            DateUtils.getDatetimeString(),
+            null,
+            null,
+            null
+        );
+
+        testBoard.setBoardId(1L);
+
+        when(boardService.getBoard(any()))
+            .thenReturn(
+                new BoardVO(
+                    1L,
+                    UuidUtils.generateNoDashUUID(),
+                    "Category1",
+                    "title1",
+                    "content",
+                    0L,
+                    "user1",
+                    DateUtils.getDatetimeString(),
+                    null,
+                    null,
+                    null
+                )
+            );
+
+        mockMvc.perform(
+                post("/board/get-board-detail.do")
+                    .content(objectMapper.writeValueAsBytes(testBoard))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+            )
+            .andDo(print())
+            .andExpect(MockMvcResultMatchers.status().isOk());
+    }
+
+    @Test
+    @DisplayName("게시글 단건 조회시 댓글도 함께 조회 성공")
+    public void getBoardwithCommentsSuccess() throws Exception {
+
+        BoardVO testBoard = new BoardVO(
+            null,
+            UuidUtils.generateNoDashUUID(),
+            "Category1",
+            "title1",
+            "content",
+            0L,
+            "user1",
+            DateUtils.getDatetimeString(),
+            null,
+            null,
+            null
+        );
+
+        testBoard.setBoardId(1L);
+
+        when(boardService.getBoard(any()))
+            .thenReturn(
+                new BoardVO(
+                    1L,
+                    testBoard.getBno(),
+                    "Category1",
+                    "title1",
+                    "content",
+                    0L,
+                    "user1",
+                    DateUtils.getDatetimeString(),
+                    null,
+                    null,
+                    Arrays.asList(
+                        new ReplyVO(
+                            testBoard.getBno(),
+                            UuidUtils.generateNoDashUUID(),
+                            "content",
+                            "user22",
+                            DateUtils.getDatetimeString(),
+                            false
+                        ),
+                        new ReplyVO(
+                            testBoard.getBno(),
+                            UuidUtils.generateNoDashUUID(),
+                            "content111",
+                            "user22",
+                            DateUtils.getDatetimeString(),
+                            true
+                        ),
+                        new ReplyVO(
+                            testBoard.getBno(),
+                            UuidUtils.generateNoDashUUID(),
+                            "content222",
+                            "user22",
+                            DateUtils.getDatetimeString(),
+                            false
+                        )
+                    )
+                )
+            );
+
+        mockMvc.perform(
+                post("/board/get-board-detail.do")
+                    .content(objectMapper.writeValueAsBytes(testBoard))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+            )
+            .andDo(print())
+            .andExpect(MockMvcResultMatchers.status().isOk());
+    }
+
+    @Test
+    @DisplayName("게시글 수정 성공")
+    public void updateBoardSuccess() throws Exception {
+
+        BoardVO testBoard = new BoardVO(
+            null,
+            UuidUtils.generateNoDashUUID(),
+            "Category1",
+            "title1",
+            "content",
+            0L,
+            "user1",
+            DateUtils.getDatetimeString(),
+            null,
+            null,
+            null
+        );
+
+        testBoard.setBoardId(1L);
+
+        when(boardService.updateBoard(any()))
+            .thenReturn(
+                new BoardVO(
+                    1L,
+                    UuidUtils.generateNoDashUUID(),
+                    "Category1",
+                    "title1",
+                    "content",
+                    0L,
+                    "user1",
+                    DateUtils.getDatetimeString(),
+                    null,
+                    null,
+                    null
+                )
+            );
+
+        mockMvc.perform(
+                post("/board/update-board.do")
+                    .content(objectMapper.writeValueAsBytes(testBoard))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+            )
+            .andDo(print())
+            .andExpect(MockMvcResultMatchers.status().isOk());
+
+    }
+
+    @Test
+    @DisplayName("게시글 수정 실패")
+    public void updateBoardFail() throws Exception {
+
+        BoardVO testBoard = new BoardVO(
+            null,
+            UuidUtils.generateNoDashUUID(),
+            "Category1",
+            "title1",
+            "content",
+            0L,
+            "user1",
+            DateUtils.getDatetimeString(),
+            null,
+            null,
+            null
+        );
+
+        when(boardService.updateBoard(any()))
+            .thenThrow(new BoardException(
+                BoardErrorCode.of(HttpStatus.NOT_FOUND, BoardErrorCode.NON_EXIST_BOARD,
+                    "[bno : " + testBoard.getBno() + "]")));
+
+        mockMvc.perform(
+                post("/board/update-board.do")
+                    .content(objectMapper.writeValueAsBytes(testBoard))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+            )
+            .andDo(print())
+            .andExpect(MockMvcResultMatchers.status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("게시글 삭제 성공")
+    public void deleteBoardSuccess() throws Exception {
+
+        BoardVO testBoard = new BoardVO(
+            1L,
+            UuidUtils.generateNoDashUUID(),
+            "Category1",
+            "title1",
+            "content",
+            0L,
+            "user1",
+            DateUtils.getDatetimeString(),
+            null,
+            null,
+            null
+        );
+
+        when(boardService.deleteBoard(any()))
+            .thenReturn(
+                true
+            );
+
+        mockMvc.perform(
+                post("/board/delete-board.do")
+                    .content(objectMapper.writeValueAsBytes(testBoard))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+            )
+            .andDo(print())
+            .andExpect(MockMvcResultMatchers.status().isOk());
+
+    }
+
+
+    @Test
+    @DisplayName("댓글 등록 성공")
+    public void registerCommentSuccess() throws Exception {
+
+        ReplyVO testReplyVo = new ReplyVO(
+            UuidUtils.generateNoDashUUID(),
+            UuidUtils.generateNoDashUUID(),
+            "content1",
+            "user1",
+            DateUtils.getDatetimeString(),
+            true
+        );
+
+        when(commentService.registerReply(any()))
+            .thenReturn(
+                true
+            );
+
+        mockMvc.perform(
+                post("/board/regist-reply.do")
+                    .content(objectMapper.writeValueAsBytes(testReplyVo))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+            )
+            .andDo(print())
+            .andExpect(MockMvcResultMatchers.status().isOk());
+    }
+
+    @Test
+    @DisplayName("댓글 수정 성공")
+    public void modifyCommentSuccess() throws Exception {
+
+        ReplyVO testReplyVo = new ReplyVO(
+            UuidUtils.generateNoDashUUID(),
+            UuidUtils.generateNoDashUUID(),
+            "content1",
+            "user1",
+            DateUtils.getDatetimeString(),
+            true
+        );
+
+        when(commentService.updateReply(any()))
+            .thenReturn(
+                true
+            );
+
+        mockMvc.perform(
+                post("/board/update-reply.do")
+                    .content(objectMapper.writeValueAsBytes(testReplyVo))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+            )
+            .andDo(print())
+            .andExpect(MockMvcResultMatchers.status().isOk());
+    }
+
+    @Test
+    @DisplayName("댓글 삭제 성공")
+    public void deleteCommentSuccess() throws Exception {
+
+        ReplyVO testReplyVo = new ReplyVO(
+            UuidUtils.generateNoDashUUID(),
+            UuidUtils.generateNoDashUUID(),
+            "content1",
+            "user1",
+            DateUtils.getDatetimeString(),
+            true
+        );
+
+        when(commentService.deleteReply(any()))
+            .thenReturn(
+                true
+            );
+
+        mockMvc.perform(
+                post("/board/delete-reply.do")
+                    .content(objectMapper.writeValueAsBytes(testReplyVo))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+            )
+            .andDo(print())
+            .andExpect(MockMvcResultMatchers.status().isOk());
+    }
 }

--- a/src/test/java/com/todayworker/springboot/web/service/BoardServiceTest.java
+++ b/src/test/java/com/todayworker/springboot/web/service/BoardServiceTest.java
@@ -12,7 +12,7 @@ import com.todayworker.springboot.domain.board.jpa.entity.BoardEntity;
 import com.todayworker.springboot.domain.board.jpa.repository.BoardJpaRepository;
 import com.todayworker.springboot.domain.board.vo.BoardVO;
 import com.todayworker.springboot.domain.board.vo.ReplyVO;
-import com.todayworker.springboot.domain.common.PageableRequest;
+import com.todayworker.springboot.domain.common.dto.PageableRequest;
 import com.todayworker.springboot.elasticsearch.helper.ElasticSearchExtension;
 import com.todayworker.springboot.utils.DateUtils;
 import com.todayworker.springboot.utils.UuidUtils;
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,6 +36,9 @@ import org.springframework.transaction.annotation.Transactional;
 @ActiveProfiles("test")
 @ExtendWith(ElasticSearchExtension.class)
 public class BoardServiceTest {
+
+    @Value("${todayworker.elasticsearch.index.board}")
+    private String boardIndexName;
 
     @Autowired
     BoardService boardService;
@@ -151,7 +155,8 @@ public class BoardServiceTest {
         assertFalse(boardJpaRepository.findById(deleteBoard.getBoardId()).isPresent());
         assertFalse(
             // ElasticSearch와 동기화 되었는지 확인.
-            boardElasticSearchRepository.findById(BoardDocument.from(deleteBoard).getBoardId())
+            boardElasticSearchRepository.findById(
+                    BoardDocument.from(deleteBoard, boardIndexName).getBoardId())
                 .isPresent());
     }
 

--- a/src/test/java/com/todayworker/springboot/web/service/CommentServiceTest.java
+++ b/src/test/java/com/todayworker/springboot/web/service/CommentServiceTest.java
@@ -33,7 +33,7 @@ public class CommentServiceTest {
     CommentJpaRepository commentJpaRepository;
 
     @Autowired
-    ReplyService replyService;
+    CommentService replyService;
 
     private static final BoardVO testBoard = new BoardVO(
         null,

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -13,3 +13,4 @@ spring.security.oauth2.client.registration.google.client-id=test
 spring.security.oauth2.client.registration.google.client-secret=test
 spring.security.oauth2.client.registration.google.scope=profile,email
 todayworker.elasticsearch.index.board=board
+server.servlet.encoding.force-response=true


### PR DESCRIPTION
Issue Link : #25 

* BoardController가 Service의 리턴을 그대로 내려주도록 하였습니다.
  * 기존에 ```{data : {} }`` 로 감싸서 내려가던 JSON에서 data 부분을 통째로 내려준다고 보면 될것 같습니다.
  * 기존 글 상세보기 응답 값.
```
{
    "data": {
        "tagList": [],
        "bno": "af13bb75ed8049939f6f32690f2a4ffc",
        "cnt": 0,
        "regDate": "2022-01-25T10:26:25.341",
        "categoriName": "freeboard",
        "writer": null,
        "voteList": [],
        "title": "테스트제목",
        "reply": null,
        "content": "내용ㅇ"
    },
    "success": true
}
```
  * PR 적용 후 응답값
  ```
    {
        "boardId":1,
        "bno":"c7e748ff0691493a901d92b0d5504388",
        "categoriName":"Category1",
        "title":"title1",
        "content":"content",
        "cnt":0,
        "user":"user1",
        "regDate":"2022-01-25T17:35:53.809",
        "voteList":null,
        "tagList":null,
        "commentList":null
     }
  ```
* 공통 BaseException과 메시지 처리를 위한 Enum Class, ExceptionHandler를 구현하였습니다.
* ```BaseErrorCodeIF```를  implements 해서 에러 코드를 Enum으로 관리할 수 있고 Class 로 관리할 수 있습니다.
   * 활용 방법은 비즈로직 구현시 예외 정의가 필요 할 때 ```BaseErrorCode```(enum 형식) 과  ```BoardErrorCode```(class 형식) 두 형태중 하나로 사용하시면 됩니다.
* 서버에서 처리중 예외가 발생하면 아래와 같이 FE에 HttpStatus 코드값과 간단한 message를 body 담아서 내려주는 컨셉입니다.
![image](https://user-images.githubusercontent.com/16380977/150943881-80c84844-4046-44ad-89a1-e6be06640492.png)
