### PR TITLE
[BE] 게시글 단건 조회 시 조회수 Update 기능 추가

### DIFF
--- a/src/main/java/com/todayworker/springboot/domain/board/exception/BoardErrorCode.java
+++ b/src/main/java/com/todayworker/springboot/domain/board/exception/BoardErrorCode.java
@@ -12,6 +12,8 @@ public class BoardErrorCode implements BaseErrorCodeIF {
     public static final String NON_EXIST_BOARD = "게시글이 존재하지 않습니다. ";
     public static final String BOARD_TRANSACTION_PROCESSING_ERROR = "게시글 처리 중 에러가 발생하였습니다.";
 
+    public static final String BOARD_UPDATE_ERROR_FOR_COUNTER = "게시글 Counter update 실패";
+
     private HttpStatus errorStatus;
     private String errorMessage;
 

--- a/src/main/java/com/todayworker/springboot/domain/board/jpa/repository/BoardJpaRepository.java
+++ b/src/main/java/com/todayworker/springboot/domain/board/jpa/repository/BoardJpaRepository.java
@@ -5,9 +5,19 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface BoardJpaRepository extends JpaRepository<BoardEntity, Long> {
+
     Page<BoardEntity> findBoardEntityByOrderByRegDateDesc(Pageable pageable);
+
     Optional<BoardEntity> findBoardEntityByBno(String bno);
+
     void deleteBoardEntityByBno(String bno);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE BoardEntity b SET b.cnt = b.cnt +1 WHERE b.bno = :bno")
+    int updateBoardEntityCounterForVisit(@Param("bno") String bno);
 }

--- a/src/main/java/com/todayworker/springboot/web/service/BoardService.java
+++ b/src/main/java/com/todayworker/springboot/web/service/BoardService.java
@@ -13,6 +13,7 @@ import com.todayworker.springboot.utils.UuidUtils;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
@@ -23,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class BoardService implements BoardServiceIF {
 
     @Value("${todayworker.elasticsearch.index.board}")
@@ -49,6 +51,14 @@ public class BoardService implements BoardServiceIF {
             throw new BoardException(
                 BoardErrorCode.of(HttpStatus.BAD_REQUEST, BoardErrorCode.INVALID_BOARD,
                     "게시글 ID(bno)가 Null 일 수는 없습니다."));
+        }
+
+        // 조회수를 먼저 Update를 시도
+        // update 처리 중 예외가 발생했다 하더라도, 조회는 정상적으로 수행되어야 한다.
+        try {
+            updateBoardCounter(boardVO.getBno());
+        } catch (RuntimeException ex) {
+            log.warn("board counter update failed ", ex);
         }
 
         return boardJpaRepository
@@ -107,6 +117,16 @@ public class BoardService implements BoardServiceIF {
         } catch (Exception ex) {
             throw new BoardException(BoardErrorCode.of(HttpStatus.INTERNAL_SERVER_ERROR,
                 BoardErrorCode.BOARD_TRANSACTION_PROCESSING_ERROR), ex);
+        }
+    }
+
+    private void updateBoardCounter(String bno) {
+        if (boardJpaRepository
+            .updateBoardEntityCounterForVisit(bno) != 1) {
+            throw new BoardException(
+                BoardErrorCode.of(HttpStatus.INTERNAL_SERVER_ERROR,
+                    BoardErrorCode.BOARD_UPDATE_ERROR_FOR_COUNTER)
+            );
         }
     }
 

--- a/src/test/java/com/todayworker/springboot/web/service/BoardServiceTest.java
+++ b/src/test/java/com/todayworker/springboot/web/service/BoardServiceTest.java
@@ -22,19 +22,28 @@ import java.time.ZoneOffset;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @ActiveProfiles("test")
 @ExtendWith(ElasticSearchExtension.class)
+@DirtiesContext
+@TestInstance(Lifecycle.PER_METHOD)
 public class BoardServiceTest {
 
     @Value("${todayworker.elasticsearch.index.board}")
@@ -48,6 +57,9 @@ public class BoardServiceTest {
 
     @Autowired
     BoardElasticSearchRepository boardElasticSearchRepository;
+
+    @PersistenceContext
+    EntityManager em;
 
     private static final BoardVO testBoard = new BoardVO(
         null,
@@ -71,6 +83,18 @@ public class BoardServiceTest {
         DateUtils.getDatetimeString(),
         true
     );
+
+    @BeforeEach
+    public void setUp() {
+        this.em.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
+        this.em.createNativeQuery("TRUNCATE TABLE comments RESTART IDENTITY;").executeUpdate();
+        this.em.createNativeQuery("ALTER TABLE comments ALTER COLUMN comment_id RESTART WITH 1;")
+            .executeUpdate();
+        this.em.createNativeQuery("TRUNCATE TABLE boards RESTART IDENTITY;").executeUpdate();
+        this.em.createNativeQuery("ALTER TABLE boards ALTER COLUMN id RESTART WITH 1;")
+            .executeUpdate();
+        this.em.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
+    }
 
     @Test
     @DisplayName("Board 등록이 정상적으로 되어야 한다.")
@@ -97,7 +121,8 @@ public class BoardServiceTest {
     @DisplayName("페이징 처리된 게시글 리스트가 정상적으로 조회 되어야 한다.")
     @Transactional
     public void getBoardList() {
-        boardJpaRepository.saveAll(generateBoardList());
+        List<BoardEntity> boardEntities = boardJpaRepository.saveAll(generateBoardList());
+        boardEntities.size();
 
         PageableRequest pageableRequest = new PageableRequest();
         pageableRequest.setPageSize(10); // 사이즈 10
@@ -112,6 +137,35 @@ public class BoardServiceTest {
             System.out.println(it.getBoardId() + " | " + it.getRegDate());
         });
 
+    }
+
+    @Test
+    @DisplayName("게시글 단건 조회는 성공해야 하고, 조회수 카운트도 증가가 되어야 한다.")
+    @Transactional
+    public void findOneBoard_success() {
+        BoardEntity savedBoard = boardJpaRepository.save(BoardEntity.fromBoardVO(testBoard));
+        BoardVO searchedBoardVO = savedBoard.convertToBoardVO();
+        assertDoesNotThrow(() -> boardService.getBoard(searchedBoardVO));
+        BoardEntity retrievedBoard = boardJpaRepository.findById(savedBoard.getId()).get();
+
+        assertEquals(testBoard.getTitle(), retrievedBoard.getTitle());
+        assertEquals(1L, retrievedBoard.getCnt());
+
+        // TODO : ElasticSearch와 동기화 되었는지 확인코드 작성 필요
+    }
+
+    @Test
+    @DisplayName("게시글 단건 조회 수 만큼 조회 카운트도 증가가 되어야 한다.")
+    @Transactional
+    public void findOneBoardSeveralTries_success() {
+        BoardEntity savedBoard = boardJpaRepository.save(BoardEntity.fromBoardVO(testBoard));
+        BoardVO searchedBoardVO = savedBoard.convertToBoardVO();
+
+        IntStream.range(1, 10).forEach((it) -> {
+            System.out.println("====> current Read count : " + it);
+            BoardVO searchedVO = boardService.getBoard(searchedBoardVO);
+            assertEquals(it, searchedVO.getCnt()); // 조회한 횟 수 만큼 cnt도 증가가 되어 있어야 한다.
+        });
     }
 
     @Test

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -14,3 +14,5 @@ spring.security.oauth2.client.registration.google.client-secret=test
 spring.security.oauth2.client.registration.google.scope=profile,email
 todayworker.elasticsearch.index.board=board
 server.servlet.encoding.force-response=true
+# FOR SQL LOGGING
+logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE


### PR DESCRIPTION
* 단건 조회 **```POST /get-board-detail.do```** 호출 시 게시글 조회수(cnt)도 +1이 되도록 update 처리 로직 추가
* Update가 실패 하더라도 조회가 가능하면 게시글 조회가 이루어 지도록 트랜잭션 처리를 분리.