### PR TITLE
[BE] ElasticSearch에서 Content의 Keyword로 게시글 단순 검색 로직 구현(페이징 적용)

### DIFF
--- a/src/main/java/com/todayworker/springboot/domain/board/es/document/BoardDocument.java
+++ b/src/main/java/com/todayworker/springboot/domain/board/es/document/BoardDocument.java
@@ -26,8 +26,8 @@ public class BoardDocument {
     private String title;
     @Field(type = FieldType.Text)
     private String content;
-    @Field(type = FieldType.Integer)
-    private long cnt;
+    @Field(type = FieldType.Long)
+    private Long cnt;
     @Field(type = FieldType.Text)
     private String user;
     @Field(type = FieldType.Text)
@@ -42,6 +42,28 @@ public class BoardDocument {
             vo.getCnt(),
             vo.getUser(),
             vo.getRegDate()
+        );
+    }
+
+    public static BoardDocument of(
+        String boardId,
+        String bno,
+        String categoryName,
+        String title,
+        String content,
+        Long cnt,
+        String user,
+        String regDate
+    ) {
+        return new BoardDocument(
+            boardId,
+            bno,
+            categoryName,
+            title,
+            content,
+            cnt,
+            user,
+            regDate
         );
     }
 }

--- a/src/main/java/com/todayworker/springboot/domain/board/es/repository/BoardElasticSearchRepository.java
+++ b/src/main/java/com/todayworker/springboot/domain/board/es/repository/BoardElasticSearchRepository.java
@@ -6,6 +6,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 
 public interface BoardElasticSearchRepository extends
-        ElasticsearchRepository<BoardDocument, String> {
+    ElasticsearchRepository<BoardDocument, String> {
+
     Page<BoardDocument> findAllByOrderByRegDateDesc(Pageable pageable);
+
+    Page<BoardDocument> findBoardDocumentByContentContains(String content, Pageable pageable);
+
+    Page<BoardDocument> findByContentIgnoreCase(String content, Pageable pageable);
 }

--- a/src/main/java/com/todayworker/springboot/domain/board/vo/BoardSearchRequest.java
+++ b/src/main/java/com/todayworker/springboot/domain/board/vo/BoardSearchRequest.java
@@ -1,0 +1,15 @@
+package com.todayworker.springboot.domain.board.vo;
+
+import com.todayworker.springboot.domain.common.dto.PageableRequest;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class BoardSearchRequest {
+
+    private String writer;
+    private String content;
+    private String tagKeyword;
+    private PageableRequest paging; // 페이징 요청이 필요한 경우.
+}

--- a/src/main/java/com/todayworker/springboot/web/service/BoardSearchService.java
+++ b/src/main/java/com/todayworker/springboot/web/service/BoardSearchService.java
@@ -1,0 +1,26 @@
+package com.todayworker.springboot.web.service;
+
+import com.todayworker.springboot.domain.board.es.document.BoardDocument;
+import com.todayworker.springboot.domain.board.es.repository.BoardElasticSearchRepository;
+import com.todayworker.springboot.domain.common.dto.PageableRequest;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BoardSearchService implements BoardSearchServiceIF {
+
+    private final BoardElasticSearchRepository boardElasticSearchRepository;
+
+    @Override
+    public List<BoardDocument> searchBoardWithContent(String contentKeyword,
+        PageableRequest pageableRequest) {
+        return boardElasticSearchRepository.findByContentIgnoreCase(
+                contentKeyword,
+                PageRequest.of(pageableRequest.parseFromIndexToPageOffset(),
+                    pageableRequest.getPageSize()))
+            .toList();
+    }
+}

--- a/src/main/java/com/todayworker/springboot/web/service/BoardSearchServiceIF.java
+++ b/src/main/java/com/todayworker/springboot/web/service/BoardSearchServiceIF.java
@@ -1,0 +1,11 @@
+package com.todayworker.springboot.web.service;
+
+import com.todayworker.springboot.domain.board.es.document.BoardDocument;
+import com.todayworker.springboot.domain.common.dto.PageableRequest;
+import java.util.List;
+
+public interface BoardSearchServiceIF {
+
+    List<BoardDocument> searchBoardWithContent(String contentKeyword,
+        PageableRequest pageableRequest);
+}

--- a/src/test/java/com/todayworker/springboot/web/service/BoardSearchServiceTest.java
+++ b/src/test/java/com/todayworker/springboot/web/service/BoardSearchServiceTest.java
@@ -1,0 +1,165 @@
+package com.todayworker.springboot.web.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.todayworker.springboot.domain.board.es.document.BoardDocument;
+import com.todayworker.springboot.domain.board.es.repository.BoardElasticSearchRepository;
+import com.todayworker.springboot.domain.board.vo.BoardVO;
+import com.todayworker.springboot.domain.common.dto.PageableRequest;
+import com.todayworker.springboot.elasticsearch.helper.ElasticSearchExtension;
+import com.todayworker.springboot.utils.DateUtils;
+import com.todayworker.springboot.utils.UuidUtils;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.shaded.com.fasterxml.jackson.core.JsonProcessingException;
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@ExtendWith(ElasticSearchExtension.class)
+public class BoardSearchServiceTest {
+
+    @Autowired
+    BoardSearchService boardSearchService;
+
+    @Autowired
+    BoardElasticSearchRepository elasticSearchRepository;
+
+
+    @Value("${todayworker.elasticsearch.index.board}")
+    private String boardIndexName;
+
+    private static String[] testkeywords = {"Car", "Beauty", "Economy", "Politics", "Economic"};
+
+    private static String[] korTestkeywords = {"자동차", "미용", "경제", "정치", "재테크"};
+
+    @BeforeEach
+    public void setUp() {
+        AtomicInteger index = new AtomicInteger(0);
+
+        List<BoardDocument> testBoards = Stream.generate(() -> new BoardVO(
+                null,
+                UuidUtils.generateNoDashUUID(),
+                "category " + index.incrementAndGet(),
+                "title" + index.get(),
+                "content " + index.get() + " " + testkeywords[(index.get() / 5)],
+                0,
+                "user11",
+                DateUtils.getDatetimeString(),
+                null,
+                null,
+                null
+            ))
+            .limit(20)
+            .map(it -> BoardDocument.from(it, boardIndexName))
+            .collect(Collectors.toList());
+
+        elasticSearchRepository.saveAll(testBoards);
+    }
+
+    @AfterEach
+    public void clear() {
+        elasticSearchRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("Content에 대한 키워드 검색 페이징이 성공해야 한다.")
+    public void contentSearchSimilarTest() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        String searchKeyword = "Car";
+        PageableRequest pageableRequest = new PageableRequest();
+        pageableRequest.setFromIndex(0);
+        pageableRequest.setPageSize(2);
+        List<BoardDocument> documentList = boardSearchService.searchBoardWithContent(searchKeyword,
+            pageableRequest);
+
+        assertEquals(2, documentList.size());
+        documentList.forEach((it) -> {
+            try {
+                System.out.println("searched Documents : " + objectMapper.writeValueAsString(it));
+                assertTrue(it.getContent().contains(searchKeyword));
+            } catch (JsonProcessingException e) {
+                e.printStackTrace();
+            }
+        });
+
+
+    }
+
+    @Test
+    @DisplayName("대소문자가 다르더라도 Content에 대한 키워드 검색 페이징이 성공해야 한다.")
+    public void contentSearchSimilarDifferentCaseTest() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        String searchKeyword = "CAR";
+        PageableRequest pageableRequest = new PageableRequest();
+        pageableRequest.setFromIndex(0);
+        pageableRequest.setPageSize(2);
+        List<BoardDocument> documentList = boardSearchService.searchBoardWithContent(searchKeyword,
+            pageableRequest);
+
+        assertEquals(2, documentList.size());
+        documentList.forEach((it) -> {
+            try {
+                System.out.println("searched Documents : " + objectMapper.writeValueAsString(it));
+                assertTrue(it.getContent().contains("Car"));
+            } catch (JsonProcessingException e) {
+                e.printStackTrace();
+            }
+        });
+    }
+
+    @Test
+    @DisplayName("한글 키워드 검색 확인")
+    public void contentSearchWithKorean() {
+        AtomicInteger index = new AtomicInteger(0);
+        List<BoardDocument> koreanTestBoards = Stream.generate(() -> new BoardVO(
+                null,
+                UuidUtils.generateNoDashUUID(),
+                "category " + index.incrementAndGet(),
+                "title" + index.get(),
+                "content " + index.get() + " " + korTestkeywords[(index.get() / 5)],
+                0,
+                "user11",
+                DateUtils.getDatetimeString(),
+                null,
+                null,
+                null
+            ))
+            .limit(20)
+            .map(it -> BoardDocument.from(it, boardIndexName))
+            .collect(Collectors.toList());
+
+        elasticSearchRepository.saveAll(koreanTestBoards);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        String searchKeyword = "자동차";
+        PageableRequest pageableRequest = new PageableRequest();
+        pageableRequest.setFromIndex(0);
+        pageableRequest.setPageSize(2);
+        List<BoardDocument> documentList = boardSearchService.searchBoardWithContent(searchKeyword,
+            pageableRequest);
+
+        assertEquals(2, documentList.size());
+        documentList.forEach((it) -> {
+            try {
+                System.out.println("searched Documents : " + objectMapper.writeValueAsString(it));
+                assertTrue(it.getContent().contains("자동차"));
+            } catch (JsonProcessingException e) {
+                e.printStackTrace();
+            }
+        });
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -16,3 +16,8 @@ todayworker.elasticsearch.index.board=board
 server.servlet.encoding.force-response=true
 # FOR SQL LOGGING
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
+# FOR Elastic Search LOGGING
+logging.level.tracer=TRACE
+logging.level.org.springframework.data.elasticsearch.core=DEBUG
+logging.level.org.elasticsearch.client=TRACE
+logging.level.org.apache.http=TRACE


### PR DESCRIPTION
* Board의 Content 기준으로 ElasticSearch에서 단순 키워드 검색 연동 로직 구현
* 조회 결과에 대해서 페이징을 적용하여 받아오도록 구현

  * 게시글 본문에 ```자동차``` 라는 단어가 포함된 게시글을 페이징 해서 가져오는 요청 처리 로그
```
2022-02-12 17:24:22.235 DEBUG 35444 --- [    Test worker] org.elasticsearch.client.RestClient      : request [POST http://localhost:32821/board/_search?typed_keys=true&max_concurrent_shard_requests=5&ignore_unavailable=false&expand_wildcards=open&allow_no_indices=true&ignore_throttled=true&search_type=dfs_query_then_fetch&batched_reduce_size=512&ccs_minimize_roundtrips=true] returned [HTTP/1.1 200 OK]
2022-02-12 17:24:22.235 TRACE 35444 --- [    Test worker] tracer                                   : curl -iX POST 'http://localhost:32821/board/_search?typed_keys=true&max_concurrent_shard_requests=5&ignore_unavailable=false&expand_wildcards=open&allow_no_indices=true&ignore_throttled=true&search_type=dfs_query_then_fetch&batched_reduce_size=512&ccs_minimize_roundtrips=true' -d '{"from":0,"size":2,"query":{"bool":{"must":[{"query_string":{"query":"자동차","fields":["content^1.0"],"type":"best_fields","default_operator":"and","max_determinized_states":10000,"enable_position_increments":true,"fuzziness":"AUTO","fuzzy_prefix_length":0,"fuzzy_max_expansions":50,"phrase_slop":0,"escape":false,"auto_generate_synonyms_phrase_query":true,"fuzzy_transpositions":true,"boost":1.0}}],"adjust_pure_negative":true,"boost":1.0}},"version":true,"explain":false}'
```